### PR TITLE
Relaxed pinned package requirements for compatibility with external environments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-hexbytes==0.3.1
-numpy==1.26.4
-pandas==2.2.2
-python-dotenv==1.0.1
-requests==2.32.3
+hexbytes>=0.3.1
+numpy>=1.24.0
+pandas>=2.0.0
+python-dotenv>=1.0.0
+requests>=2.31.0
 web3==6.19.0


### PR DESCRIPTION
Strict pinning of package versions breaks external environments.

Relaxed to known good versions while keeping web3 pinned.