### PR TITLE
Relaxed pinned package requirements for compatibility with external environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name="vbase",
     version="0.0.1",
     author="PIT Labs, Inc.",
-    author_email="tech@pitlabs.xyz",
+    author_email="tech@vbase.com",
     description="vBase Python Software Development Kit (SDK)",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/vbase/core/web3_http_commitment_service.py
+++ b/vbase/core/web3_http_commitment_service.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 from dotenv import load_dotenv
 from web3 import Web3
 from web3.middleware import (
+    buffered_gas_estimate_middleware,    
     construct_sign_and_send_raw_middleware,
     geth_poa_middleware,
 )
@@ -123,6 +124,14 @@ class Web3HTTPCommitmentService(Web3CommitmentService):
             acct = w3.eth.account.from_key(private_key)
             w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
             w3.eth.default_account = acct.address
+
+        # Add gas buffer middleware to ensure txs do not run out of gas
+        # due to a missed estimate.
+        # This seems to happen occasionally on Polygon PoS.
+        # Gas estimate middleware needs to run before signing.
+        # Currently, Web3 has a number of bugs in middleware paths.
+        # We work around them by adding middleware after signing.
+        w3.middleware_onion.add(buffered_gas_estimate_middleware)
 
         # Connect to the contract.
         # Web3 library is fussy about the address parameter type.


### PR DESCRIPTION
Ran full localhost tests on requirements.txt and manually ran the same with pinned packages min versions.