### PR TITLE
keccak256 -> sha3-256 default hash change and cleanup

### DIFF
--- a/.github/workflows/test-localhost.yml
+++ b/.github/workflows/test-localhost.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        
+
     - name: Run vbase-py tests
       run: |
         chmod +x vbase/tests/scripts/run_tests_localhost.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ Thank you for considering contributing to the vBase Python Software Development 
 
 ## Reporting Issues
 
-If you encounter a bug or have a feature request, 
+If you encounter a bug or have a feature request,
 please use the GitHub Issues section of the repository to report it:
-- Check Existing Issues: 
+- Check Existing Issues:
 Make sure the issue has not already been reported or addressed.
-- Create a New Issue: 
-If your issue is new, click the "New Issue" button and select the appropriate template 
+- Create a New Issue:
+If your issue is new, click the "New Issue" button and select the appropriate template
 (bug report or feature request).
-- Fill Out the Template: 
+- Fill Out the Template:
 Provide as much information as possible to help us understand the problem or feature.
 
 ## Making Contributions

--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -16,6 +16,6 @@ for the latest vBase release.
     * CommitmentsService
       * Address: `0x80D2AB15EE5b91cD7A183b8938dC277fE6191F7d`
       * [Deployment transaction](https://polygonscan.com/tx/0xb60915c7a8da9a277d09e7f9807ba70d75f203040135faa6f77d555c12918b84)
-    * CommitmentsServiceTest 
+    * CommitmentsServiceTest
       * Address: `0xD4dF7c779beEd417aD02adf6129949183a932263`
       * [Deployment transaction](https://polygonscan.com/tx/0xf57bcde72d657e14412d5bf9214e4195b8721546f356820ed148f08e29bd9a97)

--- a/docs/dataset_commitments.md
+++ b/docs/dataset_commitments.md
@@ -1,6 +1,6 @@
 # Dataset Commitments
 
-Below is a survey of the principles for making effective commitments 
+Below is a survey of the principles for making effective commitments
 that deliver maximum value for data consumers.
 
 ## General Principles
@@ -21,7 +21,7 @@ requiring expensive testing.
 
 ## External Examples
 
-vBase commitments and the ability to `rewind the information to "as it actually was" ` 
+vBase commitments and the ability to `rewind the information to "as it actually was" `
 enable bitemporal modeling for any data: https://en.wikipedia.org/wiki/Bitemporal_modeling.
 Indeed, the underlying objective cryptographic commitments enable verification,
 bitemporal modeling, and historical simulation for any untrusted 3rd party data
@@ -34,16 +34,16 @@ important macroeconomic series with frequent revisions:
 
 ## vBase Commitment Examples
 
-We will use the above Total Nonfarm (PAYEMS) series 
+We will use the above Total Nonfarm (PAYEMS) series
 to illustrate how vBase commitments establish high-fidelity "vintage timestamps"
 identifying when data and its revisions became available.
 
-For simplicity, we will assume all commitments are made at midnight GMT, 
-beginning with the `20221104` vintage. 
+For simplicity, we will assume all commitments are made at midnight GMT,
+beginning with the `20221104` vintage.
 
 ### Initial commitment
 
-The initial dataset is the full history for the `2022-11-04` vintage: 
+The initial dataset is the full history for the `2022-11-04` vintage:
 ```
 t           value
 1939-01-01	29923
@@ -55,7 +55,7 @@ t           value
 2022-10-01	153308
 ```
 
-These initial and subsequent records can be committed as 
+These initial and subsequent records can be committed as
 `VBaseJsonSeries` or `VBaseStringSeries` objects.
 If data is available in an AWS S3 bucket,
 it can also be committed using the `commit_s3_objects` tool:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
 -r requirements.txt
-pymongo-4.8.0
+black==24.8.0
+pre-commit==3.8.0
+PyYAML==6.0.2
+pylint==3.2.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-black==24.8.0
-pre-commit==3.8.0
-PyYAML==6.0.2
-pylint==3.2.7
+black>=24.8.0
+pre-commit>=3.8.0
+PyYAML>=6.0.2
+pylint>=3.2.7

--- a/vbase/core/vbase_dataset.py
+++ b/vbase/core/vbase_dataset.py
@@ -17,7 +17,7 @@ from vbase.core.vbase_object import VBaseObject, VBASE_OBJECT_TYPES
 from vbase.core.indexing_service import IndexingService
 from vbase.utils.crypto_utils import (
     add_int_uint256,
-    solidity_hash,
+    hash_typed_values,
 )
 from vbase.utils.log import get_default_logger
 
@@ -229,7 +229,7 @@ class VBaseDataset(ABC):
         :param dataset_name: The dataset name.
         :return: The CID for the dataset.
         """
-        return solidity_hash(["string"], [dataset_name]).hex()
+        return hash_typed_values(["string"], [dataset_name])
 
     def _add_record_worker(
         self, record: VBaseObject, object_cid: str, timestamp: pd.Timestamp

--- a/vbase/core/vbase_object.py
+++ b/vbase/core/vbase_object.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from vbase.utils.crypto_utils import (
-    solidity_hash,
+    hash_typed_values,
     string_to_u64_id,
     float_to_field,
 )
@@ -137,7 +137,7 @@ class VBaseIntObject(VBaseObject):
 
     @staticmethod
     def get_cid_for_data(record_data: int) -> str:
-        return solidity_hash(["uint256"], [record_data]).hex()
+        return hash_typed_values(["uint256"], [record_data])
 
 
 class VBasePrivateIntObject(VBaseObject):
@@ -167,9 +167,9 @@ class VBasePrivateIntObject(VBaseObject):
 
     @staticmethod
     def get_cid_for_data(record_data: Tuple[int, str]) -> str:
-        return solidity_hash(
+        return hash_typed_values(
             ["uint256", "string"], [record_data[0], record_data[1]]
-        ).hex()
+        )
 
 
 class VBaseFloatObject(VBaseObject):
@@ -191,7 +191,7 @@ class VBaseFloatObject(VBaseObject):
 
     @staticmethod
     def get_cid_for_data(record_data: float) -> str:
-        return solidity_hash(["uint256"], [float_to_field(record_data)]).hex()
+        return hash_typed_values(["uint256"], [float_to_field(record_data)])
 
 
 class VBasePrivateFloatObject(VBaseObject):
@@ -218,10 +218,10 @@ class VBasePrivateFloatObject(VBaseObject):
 
     @staticmethod
     def get_cid_for_data(record_data: Tuple[int, str]) -> str:
-        return solidity_hash(
+        return hash_typed_values(
             ["uint256", "string"],
             [float_to_field(record_data[0]), record_data[1]],
-        ).hex()
+        )
 
 
 class VBaseStringObject(VBaseObject):
@@ -242,7 +242,7 @@ class VBaseStringObject(VBaseObject):
 
     @staticmethod
     def get_cid_for_data(record_data: str) -> str:
-        return solidity_hash(["string"], [record_data]).hex()
+        return hash_typed_values(["string"], [record_data])
 
 
 class VBaseJsonObject(VBaseObject):
@@ -300,10 +300,10 @@ class VBasePortfolioObject(VBaseObject):
         # fixed point base -- uint256.
         vals: List[Any] = [float_to_field(val) for val in list(record_data.values())]
         # Both arrays are concatenated to calculate the hash.
-        return solidity_hash(
+        return hash_typed_values(
             ["uint64"] * len(ids) + ["uint256"] * len(vals),
             ids + vals,
-        ).hex()
+        )
 
 
 VBASE_OBJECT_TYPES = {

--- a/vbase/core/web3_commitment_service.py
+++ b/vbase/core/web3_commitment_service.py
@@ -20,7 +20,7 @@ from web3.types import TxReceipt
 
 from vbase.core.commitment_service import CommitmentService
 from vbase.utils.log import get_default_logger
-from vbase.utils.crypto_utils import bytes_to_hex_str
+from vbase.utils.crypto_utils import bytes_to_hex_str, hash_typed_values
 
 
 _LOG = get_default_logger(__name__)
@@ -70,7 +70,7 @@ class Web3CommitmentService(CommitmentService, ABC):
         return self.w3.eth.accounts[0]
 
     def get_named_set_cid(self, name: str) -> str:
-        return self.w3.solidity_keccak(abi_types=["string"], values=[name]).hex()
+        return hash_typed_values(abi_types=["string"], values=[name])
 
     @staticmethod
     def convert_timestamp_str_to_chain(ts: str) -> int:

--- a/vbase/tests/test_crypto_utils.py
+++ b/vbase/tests/test_crypto_utils.py
@@ -1,0 +1,119 @@
+"""
+Test crypto utilities
+"""
+
+import hashlib
+import unittest
+from web3 import Web3
+
+from vbase.utils.crypto_utils import (
+    solidity_hash_typed_values,
+    convert_typed_values_to_bytes,
+    hash_typed_values,
+)
+
+
+_STR_TEST = "Hello, world!"
+_INT_TEST1 = 42
+_INT_TEST2 = 43
+
+
+def sha3_256_hash_bytes(data: bytes) -> str:
+    """
+    Compute a SHA3-256 hash of a byte array.
+    """
+    hash_obj = hashlib.sha3_256()
+    hash_obj.update(data)
+    sha3_hash = "0x" + hash_obj.digest().hex()
+    return sha3_hash
+
+
+class TestCryptoUtils(unittest.TestCase):
+    """
+    Test vBase crypto utilities
+    """
+
+    def test_str_hash(self):
+        """
+        Test hash of a string against reference values.
+        """
+        # Verify (keccak-256) solidity_hash_typed_values for a string.
+        sol_hash = solidity_hash_typed_values(["string"], [_STR_TEST])
+        keccak_hash = Web3.keccak(text=_STR_TEST).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        # Verify the same hash using the marshalling function.
+        keccak_hash = Web3.keccak(
+            convert_typed_values_to_bytes(["string"], [_STR_TEST])
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        # Verify (sha3-256) hash_typed_values for a string.
+        vbase_hash = hash_typed_values(["string"], [_STR_TEST])
+        sha3_hash = sha3_256_hash_bytes(_STR_TEST.encode("utf-8"))
+        self.assertEqual(vbase_hash, sha3_hash)
+
+    def test_int_hash(self):
+        """
+        Test hash of an integer against reference values.
+        """
+        sol_hash = solidity_hash_typed_values(["uint256"], [_INT_TEST1])
+        keccak_hash = Web3.keccak(_INT_TEST1.to_bytes(32, byteorder="big")).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        keccak_hash = Web3.keccak(
+            convert_typed_values_to_bytes(["uint256"], [_INT_TEST1])
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        vbase_hash = hash_typed_values(["uint256"], [_INT_TEST1])
+        sha3_hash = sha3_256_hash_bytes(_INT_TEST1.to_bytes(32, byteorder="big"))
+        self.assertEqual(vbase_hash, sha3_hash)
+
+    def test_2ints_hash(self):
+        """
+        Test hash of two integers against reference values.
+        """
+        sol_hash = solidity_hash_typed_values(
+            ["uint256", "uint256"], [_INT_TEST1, _INT_TEST2]
+        )
+        keccak_hash = Web3.keccak(
+            _INT_TEST1.to_bytes(32, byteorder="big")
+            + _INT_TEST2.to_bytes(32, byteorder="big")
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        keccak_hash = Web3.keccak(
+            convert_typed_values_to_bytes(
+                ["uint256", "uint256"], [_INT_TEST1, _INT_TEST2]
+            )
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        vbase_hash = hash_typed_values(["uint256", "uint256"], [_INT_TEST1, _INT_TEST2])
+        sha3_hash = sha3_256_hash_bytes(
+            _INT_TEST1.to_bytes(32, byteorder="big")
+            + _INT_TEST2.to_bytes(32, byteorder="big")
+        )
+        self.assertEqual(vbase_hash, sha3_hash)
+
+    def test_str_int_hash(self):
+        """
+        Test hash of a string followed by an integer against reference values.
+        """
+        sol_hash = solidity_hash_typed_values(
+            ["string", "uint256"], [_STR_TEST, _INT_TEST2]
+        )
+        keccak_hash = Web3.keccak(
+            _STR_TEST.encode("utf-8") + _INT_TEST2.to_bytes(32, byteorder="big")
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        keccak_hash = Web3.keccak(
+            convert_typed_values_to_bytes(
+                ["string", "uint256"], [_STR_TEST, _INT_TEST2]
+            )
+        ).hex()
+        self.assertEqual(sol_hash, keccak_hash)
+        vbase_hash = hash_typed_values(["string", "uint256"], [_STR_TEST, _INT_TEST2])
+        sha3_hash = sha3_256_hash_bytes(
+            _STR_TEST.encode("utf-8") + _INT_TEST2.to_bytes(32, byteorder="big")
+        )
+        self.assertEqual(vbase_hash, sha3_hash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_indexing_service.py
+++ b/vbase/tests/test_indexing_service.py
@@ -193,3 +193,7 @@ class TestIndexingService(unittest.TestCase):
         object_cid = "0x" + secrets.token_bytes(32).hex()
         commitment_receipt = self.indexing_service.find_last_object(object_cid)
         assert commitment_receipt is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_indexing_service_dual_localhost.py
+++ b/vbase/tests/test_indexing_service_dual_localhost.py
@@ -128,3 +128,7 @@ class TestIndexingServiceDual(unittest.TestCase):
                 "timestamp": cl2["timestamp"],
             },
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_sim.py
+++ b/vbase/tests/test_sim.py
@@ -88,3 +88,7 @@ class TestSim(unittest.TestCase):
         s_sim = self.vbc.run_pit_sim(ts=pd.DatetimeIndex(ts), callback=callback)
         _LOG.info("self.vbase.run_pit_sim(): ret =\n%s", s_sim)
         assert s_sim.equals(pd.Series(np.array(range(1, 6)) ** 2, index=ts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_sim.py
+++ b/vbase/tests/test_sim.py
@@ -67,7 +67,6 @@ class TestSim(unittest.TestCase):
             )
             assert cl["timestamp"] == self.vbc.normalize_pd_timestamp(t)
             time.sleep(1)
-        assert cl is not None
         assert self.vbc.verify_user_set_objects(
             dsw.owner, dsw.cid, str(hex(dsw.object_cid_sum))
         )

--- a/vbase/tests/test_vbase_client.py
+++ b/vbase/tests/test_vbase_client.py
@@ -178,3 +178,7 @@ class TestVBaseClient(unittest.TestCase):
             TEST_HASH1, object_hashes, timestamps
         )
         self._verify_sets_objects_batch(cl, object_hashes, timestamps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_vbase_dataset.py
+++ b/vbase/tests/test_vbase_dataset.py
@@ -317,3 +317,7 @@ class TestVBaseDataset(unittest.TestCase):
         assert l_log[0].startswith(
             "Invalid record: Failed to find timestamp for object"
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_vbase_dataset_bootstrap.py
+++ b/vbase/tests/test_vbase_dataset_bootstrap.py
@@ -86,3 +86,7 @@ class TestVBaseDatasetBootstrap(unittest.TestCase):
         )
 
         dataset_from_json_checks(self.vbc, dsw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase/tests/test_vbase_dataset_bootstrap.py
+++ b/vbase/tests/test_vbase_dataset_bootstrap.py
@@ -47,7 +47,6 @@ class TestVBaseDatasetBootstrap(unittest.TestCase):
             )
             assert cl["timestamp"] == ts
             time.sleep(1)
-        assert cl is not None
         assert self.vbc.verify_user_set_objects(
             dsw.owner, dsw.cid, str(hex(dsw.object_cid_sum))
         )


### PR DESCRIPTION
Change to use sha3-256 by default for object CIDs. This provides better compatibility with external hashing. Now a CID of a string object is just a sha3-256 hash of the UTF-8 encoding of the string. Thorough new tests of the hashing functions have been added.