### PR TITLE
VI-102 Fix Dependabot cron schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,4 @@ updates:
     directory: "/requirements"
     schedule:
       interval: "cron"
-      cronjob: "0 * * * *"
-
+      cronjob: "0 0 * * *"


### PR DESCRIPTION
Fixes the Dependabot schedule after GitHub rejected the hourly cron expression. The pip-compile requirements layout changes were merged separately in #71.